### PR TITLE
Better cookie domain support

### DIFF
--- a/django_xsession/templates/django_xsession/loader.html
+++ b/django_xsession/templates/django_xsession/loader.html
@@ -1,3 +1,3 @@
 {% for domain in domains %}
-    <script type="text/javascript" src="http://{{ domain }}/{{ path }}"></script>
+    <script type="text/javascript" src="//{{ domain }}/{{ path }}"></script>
 {% endfor %}

--- a/django_xsession/templatetags/django_xsession.py
+++ b/django_xsession/templatetags/django_xsession.py
@@ -29,12 +29,11 @@ def xsession_loader(context):
     except KeyError:
         return {}
 
-    # Build domain list
+    # Build domain list, with support for subdomains
     domains = copy.copy(settings.XSESSION_DOMAINS)
-    try:
-        domains.remove(host)
-    except ValueError:
-        pass
+    for domain in settings.XSESSION_DOMAINS:
+        if host.endswith(domain):
+            domains.remove(domain)
 
     render_context = {
         'path': getattr(settings, 'XSESSION_FILENAME', 'xsession_loader.js'),

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='django_xsession',
-      version='0.1-custom1',
+      version='0.1-custom2',
       description='Django middleware that allows cookie sharing across multiple domains.',
       author='Factor AG',
       author_email='webmaster@factor.ch',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='django_xsession',
-      version='0.1-custom2',
+      version='0.1-custom3',
       description='Django middleware that allows cookie sharing across multiple domains.',
       author='Factor AG',
       author_email='webmaster@factor.ch',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='django_xsession',
-      version='0.1',
+      version='0.1-custom1',
       description='Django middleware that allows cookie sharing across multiple domains.',
       author='Factor AG',
       author_email='webmaster@factor.ch',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='django_xsession',
-      version='0.1-custom3',
+      version='0.1',
       description='Django middleware that allows cookie sharing across multiple domains.',
       author='Factor AG',
       author_email='webmaster@factor.ch',


### PR DESCRIPTION
1.  We noticed that sometimes, based on other middleware we wrote, we'd return a `Request` object without a `session` or `user` attribute.  So we instead check to see if the attribute is available, now.

2.  We now issue `delete_cookie` to *either* the SESSION_COOKIE_DOMAIN or the custom domain you may be on.  This behavior should have been in the initial patch, and without it we had some lingering issues in our testing.